### PR TITLE
Update transactions.js

### DIFF
--- a/lib/controllers/transactions.js
+++ b/lib/controllers/transactions.js
@@ -16,6 +16,9 @@ module.exports = {
         .set(headers)
         .send(options)
         .endAsync().then(function(response) {
+          if (!response.body.success) {
+            return reject(new Error(response.body.errors));
+          }
           resolve(response.body);
         })
         .error(reject);


### PR DESCRIPTION
[FIX] In the event of an edge case (ie. invalid funds etc), Coinbase still returns a 200 response, this fix serves to parse the actual response and make sure it was successful
